### PR TITLE
Pin Django versions and support for 3.11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -11,9 +11,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
   style:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.6
+        python-version: 3.11
     - name: Install tox
       run: pip install tox
     - name: Style check
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9, 3.11]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -43,7 +43,7 @@ jobs:
 
     - name: coverage xml
       run: .tox/py/bin/coverage xml
-    - uses: codecov/codecov-action@v2
+    - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    Django >= 3.0
+    Django >= 3.0, < 4
     elasticsearch >= 6.8, < 7
     # TODO: make tqdm optional
     tqdm >= 4, < 5

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     flake8
     py{39}-dj{22,30,32}
+    py{311}-dj{22,30,32}
 
 [testenv]
 deps =
@@ -12,7 +13,7 @@ deps =
 setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = testapp.settings
-whitelist_externals = make
+allowlist_externals = make
 pip_pre = True
 commands = make coverage TEST_ARGS='{posargs:tests}'
 
@@ -26,6 +27,6 @@ skip_install = true
 basepython = python3
 commands = make style_check
 deps =
-    black>=19.10b0
+    black>=22.12.0
     flake8
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
     flake8
-    py{39}-dj{22,30,32}
-    py{311}-dj{22,30,32}
+    py{39,311}-dj{22,30,32}
 
 [testenv]
 deps =


### PR DESCRIPTION
- pin Django version until we have better integration tests;
- add Python 3.11 support in tests
- Closes #5 