### PR TITLE
feature: support lifecycle policies on index creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,63 @@
 # django-olympus
 
-Collect data from django models into ElasticSearch
+[![build-status-image]][build-status]
+[![coverage-status-image]][codecov]
+[![pypi-version]][pypi]
 
-## TODO
+Collect data from django models into ElasticSearch.
 
-- integration tests: spin up a docker with ES and run a collector from the test app
-- support different elasticsearch version (and libs) using option.extra.installs?
-- DOCS!
+This Django application provides a `OlympusCollector` class that is a wrapper for the `ElasticSearch` API and database 
+(using their official package).
+
+To know more about how to use it, please check the [Setup](#setup) section.
+
+## Setup
+
+After adding `django-olympus` as part of your required packages, add `olympus` to `INSTALLED_APPS` in your `settings.py`.
+
+The following settings are available for customization:
+
+| Name | Default | Description |
+| ---- | ------- | ----------- |
+| OLYMPUS_ELASTICSEARCH_URL | None | This should point to the **ElasticSearch** server running. |
+| OLYMPUS_ELASTICSEARCH_VERIFY_CERTS | None | This should tell whether certificates should be verified - only set this to false for local development |
+
+Since this application provides a baseline Collector class, this will help you bootstrap data collectors to send 
+information to `ElasticSearch`. The following section details how to write your own collectors.
+
+### Collectors
+
+To create your own collector, in any Django app of your project, extend the `OlympusCollector` class and implement the 
+`collect` method to specify all the logic you need.
+
+```python
+#myapp/occ.py
+from olympus.base import OlympusCollector
+
+
+class SampleCollector(OlympusCollector):
+    index_name = "sample_collector"  # can be anything you'd like.
+    index_date_pattern = "%Y.%m.%d"  # can be anything you'd like.
+    index_lifecycle_name = "something"  # if you use default lifecycle policies and would like to assign a different one.
+
+    def collect(self):
+        self.logger.info(f"started {self.index_name}")  # Base class provides built-in logging.
+
+        data = some_func()  # Some logic to retrieve data, either from API, from Django's Database or whatever.
+
+        yield = {
+            "_id": "1",  # _id is mandatory and can be anything, really, as long as it is unique.
+            "some": data.attribute,
+            "more": data.attribute2,
+        }
+```
+
+To keep collectors organized, you might want to create an `occ.py` file in each app, implementing the collectors. Each 
+app can implement as many collectors as necessary, there is really no restrictions.
+
+`olympus` API provides a `Django` command called `push_to_es` which allows you to run a collector. To run the sample 
+above, `./manage.py push_to_es myapp.SampleCollector` would be required.
+
+**Apps with collectors must be part of your `settings.py` file, otherwise collectors are not initialized and not added** 
+**to the list - hence `push_to_es` will fail.**
+

--- a/olympus/base.py
+++ b/olympus/base.py
@@ -24,6 +24,7 @@ class ElasticSearchClient(Elasticsearch):
 class OlympusCollector:
     index_name: Optional[str] = None
     index_date_pattern: Optional[str] = None
+    index_lifecycle_name: Optional[str] = None
     chunk_size = 500
     alias_suffix = '-latest'
 
@@ -58,7 +59,11 @@ class OlympusCollector:
         return f"{cls.__module__.split('.')[0]}.{cls.__name__}"
 
     def create_index(self):
-        self.es.indices.create(index=self.get_index_name(), ignore=400)
+        body = dict()
+        if self.index_lifecycle_name:
+            body["settings"] = {"index.lifecycle.name": self.index_lifecycle_name}
+
+        self.es.indices.create(index=self.get_index_name(), body=body, ignore=400)
         if self.index_date_pattern and self.alias_suffix:
             # Create unique alias for latest index
             alias = self.__get_raw_index_name() + self.alias_suffix

--- a/testapp/testapp/occ.py
+++ b/testapp/testapp/occ.py
@@ -1,0 +1,26 @@
+from olympus.base import OlympusCollector
+
+
+class LifecycleCollector(OlympusCollector):
+    """
+    LifecycleCollector is a demo collector for the testapp, which serves to test the creation of indices in a live
+    ElasticSearch database.
+    **Beware the lifecycle policy name must exist in the ElasticSearch before creation.**
+    To run this specific command (although not advised because this is simply a test command):
+        - Setup ElasticSearch with the app, by using the variables `OLYMPUS_ELASTICSEARCH_URL`and
+          `OLYMPUS_ELASTICSEARCH_VERIFY_CERTS`.
+        - Check the apps with `occ.py` files are included in the main settings file, otherwise collectors are not
+          loaded.
+    """
+
+    index_name = "lifecycle_collector"
+    index_date_pattern = "%Y.%m.%d"
+    index_lifecycle_name = "test"
+
+    def collect(self):
+        yield {
+            "_id": "1",
+            "key": "value",
+        }
+
+        self.logger.info(f"pushed {self.index_name} to ES successfully")

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'olympus',
+    'testapp',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
ElasticSearch supports multiple lifecycle policies but when instances have many daily indexes, updating all existing indexes lifecycle policies can be cumbersome. Hence, to facilitate its management, collectors can specify lifecycle policies instead of attaching the default one (if your ElasticSearch has one, otherwise it's simply empty) which can be useful if you have different types of collectors and wish to apply different policies to them.